### PR TITLE
Add path index column to the edge table

### DIFF
--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModel.java
@@ -650,9 +650,6 @@ public class PathLinkerModel {
 
 		kspSubgraph = root.addSubNetwork(nodesToAdd, edgesToAdd);
 
-		// create a new attribute "rank" in the network edge table
-		kspSubgraph.getTable(CyEdge.class, CyNetwork.LOCAL_ATTRS).createColumn("rank", Boolean.class, false);
-		
 		// sets the network name
 		String subgraphName = "PathLinker-subnetwork-" + k + "-paths";
 		kspSubgraph.getRow(kspSubgraph).set(CyNetwork.NAME, subgraphName);

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModel.java
@@ -650,6 +650,9 @@ public class PathLinkerModel {
 
 		kspSubgraph = root.addSubNetwork(nodesToAdd, edgesToAdd);
 
+		// create a new attribute "rank" in the network edge table
+		kspSubgraph.getTable(CyEdge.class, CyNetwork.LOCAL_ATTRS).createColumn("rank", Boolean.class, false);
+		
 		// sets the network name
 		String subgraphName = "PathLinker-subnetwork-" + k + "-paths";
 		kspSubgraph.getRow(kspSubgraph).set(CyNetwork.NAME, subgraphName);

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerPanel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerPanel.java
@@ -561,9 +561,11 @@ public class PathLinkerPanel extends JPanel implements CytoPanelComponent {
 				// add all of the directed edges from node1 to node2
 				List<CyEdge> edges = _originalNetwork.getConnectingEdgeList(node1, node2, CyEdge.Type.DIRECTED);
 				for (CyEdge edge : edges)
-					if (_originalNetwork.getRow(edge).get(columnName, Integer.class) == null)
+				{
+					if (_originalNetwork.getRow(edge).get(columnName, Integer.class) == null &&
+							edge.getSource().equals(node1) && edge.getTarget().equals(node2)) // verifies the edges direction
 						_originalNetwork.getRow(edge).set(columnName, i + 1);
-
+				}
 				// also add all of the undirected edges from node1 to node2
 				edges = _originalNetwork.getConnectingEdgeList(node1, node2, CyEdge.Type.UNDIRECTED);
 				for (CyEdge edge : edges) 


### PR DESCRIPTION
Fix issue 4 by adding new attribute to the edge table. The implementation is in PathLinkerPanel class because its main goal is to edit user GUI, in this case, the table panel.

Keep in mind that this method is ranking the edges assuming that sorting algorithm has already implemented.