### PR TITLE
Pathlinker #44: Small GUI updates

### DIFF
--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
@@ -59,7 +59,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 	private JTextField _sourcesTextField;
 	private JTextField _targetsTextField;
 	private JTextField _kTextField;
-	private JTextField _edgePenaltyTextField;
+	private static JTextField _edgePenaltyTextField;
 	protected static JButton _loadNodeToSourceButton;
 	protected static JButton _loadNodeToTargetButton;
 	private JButton _clearSourceTargetPanelButton;
@@ -68,8 +68,8 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 	protected static JComboBox<String> _edgeWeightColumnBox;
 	private ButtonGroup _weightedOptionGroup;
 	private static JRadioButton _unweighted;
-	private JRadioButton _weightedAdditive;
-	private JRadioButton _weightedProbabilities;
+	private static JRadioButton _weightedAdditive;
+	private static JRadioButton _weightedProbabilities;
 	private JCheckBox _allowSourcesTargetsInPathsOption;
 	private JCheckBox _targetsSameAsSourcesOption;
 	private JCheckBox _includePathScoreTiesOption;
@@ -212,6 +212,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		@Override
 		public void actionPerformed(ActionEvent e) {
 			updateEdgeWeightColumn();
+			updateEdgePenaltyTextField();
 		}
 	}
 
@@ -331,6 +332,18 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 					|| column.getType() == Long.class))
 				_edgeWeightColumnBox.addItem(column.getName());		
 		}
+	}
+	
+	/**
+     * update the edge penalty text field for selecting edge weight
+     * Called by PathLinkerColumnUpdateListener class if event triggered
+     */
+	private static void updateEdgePenaltyTextField() {
+	    if (_unweighted.isSelected()) {
+	        _edgePenaltyTextField.setText("");
+	        _edgePenaltyTextField.setEditable(false);
+	    }
+	    else _edgePenaltyTextField.setEditable(true);
 	}
 
 	/** enables/disable the _clearSourceTargetPanelButton 
@@ -1001,6 +1014,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 
 		_unweighted.setSelected(true);
 		updateEdgeWeightColumn();
+		updateEdgePenaltyTextField();
 
 		_innerPanelConstraints.weightx = 1;
 		_innerPanelConstraints.gridx = 0;

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
@@ -846,7 +846,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		constraint.gridwidth = 3;
 		sourceTargetPanel.add(_sourcesTextField, constraint);
 
-		_loadNodeToSourceButton = new JButton("Add selected node(s)");
+		_loadNodeToSourceButton = new JButton("Add selected source(s)");
 		_loadNodeToSourceButton.setToolTipText("Add selected node(s) from the network view into the sources field");
 		_loadNodeToSourceButton.setEnabled(false);
 		_loadNodeToSourceButton.addActionListener(new LoadNodeToSourceButtonListener());
@@ -873,7 +873,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		constraint.gridwidth = 3;
 		sourceTargetPanel.add(_targetsTextField, constraint);
 
-		_loadNodeToTargetButton = new JButton("Add selected node(s)");
+		_loadNodeToTargetButton = new JButton("Add selected target(s)");
 		_loadNodeToTargetButton.setToolTipText("Add selected node(s) from the network view into the targets field");
 		_loadNodeToTargetButton.setEnabled(false);
 		_loadNodeToTargetButton.addActionListener(new LoadNodeToTargetButtonListener());

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
@@ -70,7 +70,6 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 	private static JRadioButton _unweighted;
 	private JRadioButton _weightedAdditive;
 	private JRadioButton _weightedProbabilities;
-	private JCheckBox _subgraphOption;
 	private JCheckBox _allowSourcesTargetsInPathsOption;
 	private JCheckBox _targetsSameAsSourcesOption;
 	private JCheckBox _includePathScoreTiesOption;
@@ -415,9 +414,9 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 
 		// initialize the model from the user inputs
 		_model= new PathLinkerModel(_originalNetwork, _allowSourcesTargetsInPathsOption.isSelected(), 
-				_includePathScoreTiesOption.isSelected(), _subgraphOption.isSelected(),
-				_sourcesTextField.getText().trim(), _targetsTextField.getText().trim(), 
-				_edgeWeightColumnName, _kValue, _edgeWeightSetting, _edgePenalty);
+				_includePathScoreTiesOption.isSelected(), _sourcesTextField.getText().trim(), 
+				_targetsTextField.getText().trim(), _edgeWeightColumnName, 
+				_kValue, _edgeWeightSetting, _edgePenalty);
 
 		// sets up the source and targets, and check to see if network is construct correctly
 		success = _model.prepareIdSourceTarget();
@@ -434,9 +433,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		ArrayList<Path> result = _model.runKSP();
 
 		// generates a subgraph of the nodes and edges involved in the resulting paths and displays it to the user
-		if (!_model.getDisableSubgraph()) {
-			createKSPSubgraphAndView();
-		}
+		createKSPSubgraphAndView();
 
 		// update the table path index attribute
 		updatePathIndexAttribute(result);
@@ -1032,14 +1029,6 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		constraint.gridy = 0;
 		constraint.gridwidth = 1;
 		subGraphPanel.add(_includePathScoreTiesOption, constraint);
-
-		_subgraphOption = new JCheckBox("Disable subnetwork generation");
-		_subgraphOption.setToolTipText("Disable generation of the subnetwork of the nodes/edges involved in the k paths");
-		constraint.weightx = 1;
-		constraint.gridx = 0;
-		constraint.gridy = 1;
-		constraint.gridwidth = 1;
-		subGraphPanel.add(_subgraphOption, constraint);
 
 		_innerPanelConstraints.weightx = 1;
 		_innerPanelConstraints.gridx = 0;

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
@@ -66,7 +66,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 	private JButton _submitButton;
 	private JLabel _edgeWeightColumnBoxLabel;
 	protected static JComboBox<String> _edgeWeightColumnBox;
-	private ButtonGroup _weightedOptionGroup;
+	private static ButtonGroup _weightedOptionGroup;
 	private static JRadioButton _unweighted;
 	private static JRadioButton _weightedAdditive;
 	private static JRadioButton _weightedProbabilities;
@@ -107,6 +107,8 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 	private EdgeWeightSetting _edgeWeightSetting;
 	/** The value by which to penalize each edge weight */
 	private double _edgePenalty;
+	/** The string representation of the edge weight button selection user selected */
+	private static String _savedEdgeWeightSelection;
 	/** The StringBuilder that construct error messages if any to the user */
 	private StringBuilder errorMessage;
 
@@ -335,15 +337,35 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 	}
 	
 	/**
-     * update the edge penalty text field for selecting edge weight
-     * Called by PathLinkerColumnUpdateListener class if event triggered
+     * update the edge penalty text field depending on user's selection edge weight radio button
+     * Called by RadioButtonListener class if user selects a radio button
      */
 	private static void updateEdgePenaltyTextField() {
+	    
+	    // if user clicks on the same button that is previously selected then do nothing
+	    if (_savedEdgeWeightSelection.equals(_weightedOptionGroup.getSelection().getActionCommand()))
+	        return;
+	    
+	    // saves user's new selection to the string
+	    _savedEdgeWeightSelection = _weightedOptionGroup.getSelection().getActionCommand();
+	    
+	    // clear and disable the edge penalty text field if user selects unweighted option, otherwise enable the text field
+	    // if select weighted additive -> default is set to 0
+	    // if select weighted probabilities -> default is set to 1
 	    if (_unweighted.isSelected()) {
 	        _edgePenaltyTextField.setText("");
 	        _edgePenaltyTextField.setEditable(false);
+	        
+	        _savedEdgeWeightSelection = "unweighted";
 	    }
-	    else _edgePenaltyTextField.setEditable(true);
+	    else {
+	        _edgePenaltyTextField.setEditable(true);
+	        
+	        if (_weightedAdditive.isSelected())
+	            _edgePenaltyTextField.setText("0");
+	        else
+	            _edgePenaltyTextField.setText("1");
+	    }
 	}
 
 	/** enables/disable the _clearSourceTargetPanelButton 
@@ -963,7 +985,10 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		constraint.fill = GridBagConstraints.HORIZONTAL;
 		constraint.anchor = GridBagConstraints.LINE_START;
 
+		_savedEdgeWeightSelection = ""; // initialize the string
+		
 		_unweighted = new JRadioButton("Unweighted");
+		_unweighted.setActionCommand("unweighted");
 		_unweighted.setToolTipText("PathLinker will compute the k lowest cost paths, where the cost is the number of edges in the path.");
 		_unweighted.addActionListener(new RadioButtonListener());
 		constraint.weightx = 1;
@@ -973,6 +998,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		graphPanel.add(_unweighted, constraint);
 
 		_weightedAdditive = new JRadioButton("Weights are additive");
+		_weightedAdditive.setActionCommand("weightedAdditive");
 		_weightedAdditive.setToolTipText("PathLinker will compute the k lowest cost paths, where the cost is the sum of the edge weights.");
 		_weightedAdditive.addActionListener(new RadioButtonListener());
 		constraint.weightx = 1;
@@ -982,6 +1008,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		graphPanel.add(_weightedAdditive, constraint);
 
 		_weightedProbabilities = new JRadioButton("Weights are probabilities");
+		_weightedProbabilities.setActionCommand("weightedProbabilities");
 		_weightedProbabilities.setToolTipText("PathLinker will compute the k highest cost paths, where the cost is the product of the edge weights.");
 		_weightedProbabilities.addActionListener(new RadioButtonListener());
 		constraint.weightx = 1;

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
@@ -957,7 +957,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		constraint.gridwidth = 2;
 		graphPanel.add(_unweighted, constraint);
 
-		_weightedAdditive = new JRadioButton("Weighted Additive");
+		_weightedAdditive = new JRadioButton("Weights are additive");
 		_weightedAdditive.setToolTipText("PathLinker will compute the k lowest cost paths, where the cost is the sum of the edge weights.");
 		_weightedAdditive.addActionListener(new RadioButtonListener());
 		constraint.weightx = 1;
@@ -966,7 +966,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		constraint.gridwidth = 2;
 		graphPanel.add(_weightedAdditive, constraint);
 
-		_weightedProbabilities = new JRadioButton("Weighted Probabilities");
+		_weightedProbabilities = new JRadioButton("Weights are probabilities");
 		_weightedProbabilities.setToolTipText("PathLinker will compute the k highest cost paths, where the cost is the product of the edge weights.");
 		_weightedProbabilities.addActionListener(new RadioButtonListener());
 		constraint.weightx = 1;
@@ -1022,7 +1022,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		constraint.fill = GridBagConstraints.HORIZONTAL;
 		constraint.anchor = GridBagConstraints.LINE_START;
 
-		_includePathScoreTiesOption = new JCheckBox("Include ties");
+		_includePathScoreTiesOption = new JCheckBox("Include tied paths");
 		_includePathScoreTiesOption.setToolTipText("Include more than k paths if the path length/score is equal to the kth path's length/score");
 		constraint.weightx = 1;
 		constraint.gridx = 0;

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
@@ -866,6 +866,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 
 		_clearSourceTargetPanelButton = new JButton("Clear");
 		_clearSourceTargetPanelButton.setEnabled(false);
+		_clearSourceTargetPanelButton.setToolTipText("Clear all inputs from Sources/Targets panel");
 		_clearSourceTargetPanelButton.addActionListener(new ClearSourceTargetPanelButtonListener());
 		constraint.weightx = 0;
 		constraint.gridx = 2;

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerControlPanel.java
@@ -903,6 +903,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		algorithmPanel.add(_kLabel, constraint);
 
 		_kTextField = new JTextField(5);
+		_kTextField.setText("200");
 		_kTextField.setMinimumSize(_kTextField.getPreferredSize());
 		_kTextField.setMaximumSize(_kTextField.getPreferredSize());
 		constraint.weightx = 1;

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModel.java
@@ -65,8 +65,6 @@ public class PathLinkerModel {
 	private int commonSourcesTargets;
 	/** Whether or not to include more than k paths if the path length/score is equal to the kth path's */
 	private boolean includePathScoreTies;
-	/** Whether or not to disable subgraph */
-	private boolean disableSubgraph;
 	/** ksp subgraph */
 	private CyNetwork kspSubgraph;
 	/** sources in the ksp subgraph */
@@ -79,7 +77,6 @@ public class PathLinkerModel {
 	 * @param originalNetwork 			 the original network given by the view
 	 * @param allowSourcesTargetsInPaths boolean deciding if sources and targets should be allow in the result path
 	 * @param includePathScoreTies		 the option to include all paths of equal length
-	 * @param disableSubgraph 			 boolean deciding if need to disable subgraph
 	 * @param sourcesTextField 			 source node names in string
 	 * @param targetsTextField 			 target node names in string
 	 * @param k					 		 k value
@@ -87,13 +84,12 @@ public class PathLinkerModel {
 	 * @param edgePenalty				 edge penalty
 	 */
 	public PathLinkerModel(CyNetwork originalNetwork, boolean allowSourcesTargetsInPaths, boolean includePathScoreTies, 
-			boolean disableSubgraph, String sourcesTextField, String targetsTextField, String edgeWeightColumnName, 
+	        String sourcesTextField, String targetsTextField, String edgeWeightColumnName, 
 			int k, EdgeWeightSetting edgeWeightSetting, double edgePenalty) {
 
 		this.originalNetwork 			= originalNetwork;
 		this.allowSourcesTargetsInPaths = allowSourcesTargetsInPaths;
 		this.includePathScoreTies		= includePathScoreTies;
-		this.disableSubgraph 			= disableSubgraph;
 		this.sourcesTextField 			= sourcesTextField;
 		this.targetsTextField 			= targetsTextField;
 		this.edgeWeightColumnName		= edgeWeightColumnName;
@@ -201,14 +197,6 @@ public class PathLinkerModel {
 	 */
 	public EdgeWeightSetting getEdgeWeightSetting() {
 		return this.edgeWeightSetting;
-	}
-
-	/**
-	 * Getter method of disableSubgraph
-	 * @return disableSubgraph
-	 */
-	public boolean getDisableSubgraph() {
-		return this.disableSubgraph;
 	}
 
 	/**
@@ -375,8 +363,7 @@ public class PathLinkerModel {
 		undoLogTransformPathLength(result);
 
 		// selects all the paths that involved in the resulting for generating ksp subgraph
-		if(!disableSubgraph)
-			selectKSPSubgraph(result);
+		selectKSPSubgraph(result);
 
 		return result;
 	}

--- a/src/test/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModelTest.java
+++ b/src/test/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModelTest.java
@@ -43,8 +43,6 @@ public class PathLinkerModelTest {
 	private PathLinkerModel testModel;
 	/** Whether or not to treat all paths with same weight as one "k" path */
 	private boolean includePathScoreTies;
-	/** Whether or not to disable a subgraph */
-	private boolean disableSubgraph;
 	/** original test input strings that contains sources */
 	private String source;
 	/** original test input strings that contains targets */
@@ -78,7 +76,6 @@ public class PathLinkerModelTest {
 
 		//setting up the required variables for generating the result (same throughout the test cases)
 		includePathScoreTies = false;
-		disableSubgraph = true;
 		source = "P35968 P00533 Q02763";
 		target = "Q15797 Q14872 Q16236 P14859 P36956";
 		edgeWeightColumnName = "edge_weight";
@@ -405,8 +402,8 @@ public class PathLinkerModelTest {
 		target = "P14859 P51610";
 		
 		//create the model for algorithm with k = 26 to ensure relatively small output
-		testModel = new PathLinkerModel(originalNetworkDir, true, false, disableSubgraph, 
-				source, target, edgeWeightColumnName, 26, EdgeWeightSetting.PROBABILITIES, edgePenalty); //construct model
+		testModel = new PathLinkerModel(originalNetworkDir, true, false, source, target, 
+		        edgeWeightColumnName, 26, EdgeWeightSetting.PROBABILITIES, edgePenalty); //construct model
 		testModel.prepareIdSourceTarget();
 		resultDir = pathListToStringList(testModel.runKSP()); //construct list of paths as string to compare with ans list
 
@@ -444,7 +441,7 @@ public class PathLinkerModelTest {
 		//k value is set to enumerate all paths of length to 0.5329432500000001 ensure the results will be same,
 		//otherwise results could be correct but different due to the random nature of which paths PathLinker finds first
 		boolean allowSourceTargetInPaths = true;
-		testModel = new PathLinkerModel(originalNetworkDir, allowSourceTargetInPaths, includePathScoreTies, disableSubgraph, 
+		testModel = new PathLinkerModel(originalNetworkDir, allowSourceTargetInPaths, includePathScoreTies, 
 				source, source, edgeWeightColumnName, 37, EdgeWeightSetting.PROBABILITIES, edgePenalty);
 		testModel.prepareIdSourceTarget();
 
@@ -573,7 +570,7 @@ public class PathLinkerModelTest {
 	 * Sets up the test model before testing
 	 */
 	private void modelSetUp(CyNetwork network, int k, EdgeWeightSetting edgeWeightSetting, boolean allowSourceTargetInPaths) {
-		testModel = new PathLinkerModel(network, allowSourceTargetInPaths, includePathScoreTies, disableSubgraph, 
+		testModel = new PathLinkerModel(network, allowSourceTargetInPaths, includePathScoreTies, 
 				source, target, edgeWeightColumnName, k, edgeWeightSetting, edgePenalty); //construct model
 		testModel.prepareIdSourceTarget();
 	}


### PR DESCRIPTION
This is a small update to the GUI. These changes need to be pushed in order to push changes made Pathlinker-48 branch, for #48 

Changes include:
- remove the option to disable subnetwork generation
- change the text of "Include ties" to "Include tied paths"
- change the weights text to: "weights are additive" and "weights are probabilities"
- put the default edge penalty in the input text field
- put the default k value of 200 in the input text field
- add a tooltip for the clear button