### PR TITLE
Option to treat network as undirected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</properties>
 
 	<modelVersion>4.0.0</modelVersion>
-	<version>1.4</version>
+	<version>1.4.1</version>
 
 			<name>${bundle.symbolicName}</name>
 

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/CyActivator.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/CyActivator.java
@@ -53,6 +53,11 @@ public class CyActivator extends AbstractCyActivator
     private CIExceptionFactory ciExceptionFactory;
     private PathLinkerImpl cyRestClient;
 
+	/** the version of the current PathLinker app */
+	private String _version = "1.4.1";
+	/** the build date of the current PathLinker app */
+	private String _buildDate = "Apr. 11, 2018";
+
     @Override
     public void start(BundleContext context) throws Exception {
 
@@ -85,8 +90,8 @@ public class CyActivator extends AbstractCyActivator
                 cyApplicationManager,
                 networkManager,
                 adapter,
-                "1.4", 
-                "Oct. 25, 2017");
+                _version,
+                _buildDate);
 
         // Create PathLinker CyRest implementations
         cyRestClient = new PathLinkerImpl(

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/model/PathLinkerModel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/model/PathLinkerModel.java
@@ -459,7 +459,7 @@ public class PathLinkerModel {
 					if (edge.getSource().equals(node1) && edge.getTarget().equals(node2))
 						originalNetwork.getRow(edge).set(CyNetwork.SELECTED, true);
                     // also check the reverse direction if the network is treated as undirected
-					if treatNetworkAsUndirected && (edge.getSource().equals(node2) && edge.getTarget().equals(node1))
+					if (treatNetworkAsUndirected && (edge.getSource().equals(node2) && edge.getTarget().equals(node1)))
 						originalNetwork.getRow(edge).set(CyNetwork.SELECTED, true);
 				}
 				// also add all of the undirected edges from node1 to node2

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/model/PathLinkerModel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/model/PathLinkerModel.java
@@ -459,7 +459,7 @@ public class PathLinkerModel {
 					if (edge.getSource().equals(node1) && edge.getTarget().equals(node2))
 						originalNetwork.getRow(edge).set(CyNetwork.SELECTED, true);
                     // also check the reverse direction if the network is treated as undirected
-					if (edge.getSource().equals(node2) && edge.getTarget().equals(node1))
+					if treatNetworkAsUndirected && (edge.getSource().equals(node2) && edge.getTarget().equals(node1))
 						originalNetwork.getRow(edge).set(CyNetwork.SELECTED, true);
 				}
 				// also add all of the undirected edges from node1 to node2

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/model/PathLinkerModelParams.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/model/PathLinkerModelParams.java
@@ -48,6 +48,10 @@ public class PathLinkerModelParams {
             + "Must be numerical type values", example = "weight")
     public String edgeWeightColumnName;
 
+    @ApiModelProperty(value = "Ignore directionality of edges when computing paths",
+            example = "false", dataType = "boolean")
+    public boolean treatNetworkAsUndirected = false;
+
     @ApiModelProperty(value = "Allow source/target nodes to appear as intermediate nodes in computed paths",
             example = "false", dataType = "boolean")
     public boolean allowSourcesTargetsInPaths = false;

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/task/RunKSPTask.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/task/RunKSPTask.java
@@ -69,6 +69,7 @@ public class RunKSPTask extends AbstractNetworkTask implements ObservableTask {
         // initialize the PathLinkerModel to run ksp
         pathLinkerModel = new PathLinkerModel(
                 network, 
+                modelParams.treatNetworkAsUndirected, 
                 modelParams.allowSourcesTargetsInPaths, 
                 modelParams.includeTiedPaths, 
                 modelParams.getSourceNames(), 

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/view/PathLinkerControlPanel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/view/PathLinkerControlPanel.java
@@ -60,6 +60,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 	/** UI components of the panel */
     private JPanel _innerPanel;
 	private JPanel _titlePanel;
+	private JPanel _networkPanel;
 	private JPanel _sourceTargetPanel;
 	private JPanel _algorithmPanel;
 	private JPanel _graphPanel;
@@ -94,6 +95,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 	private JRadioButton _weightedAdditive;
 	private JRadioButton _weightedProbabilities;
 
+	private JCheckBox _treatNetworkAsUndirectedOption;
 	private JCheckBox _allowSourcesTargetsInPathsOption;
 	public JCheckBox _targetsSameAsSourcesOption;
 	private JCheckBox _includePathScoreTiesOption;
@@ -621,6 +623,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 
         // initialize the params from user inputs
         _modelParams = new PathLinkerModelParams();
+        _modelParams.treatNetworkAsUndirected = _treatNetworkAsUndirectedOption.isSelected();
         _modelParams.allowSourcesTargetsInPaths = _allowSourcesTargetsInPathsOption.isSelected();
         _modelParams.includeTiedPaths = _includePathScoreTiesOption.isSelected();
         _modelParams.sources = _sourcesTextField.getText().trim();
@@ -779,24 +782,24 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 	}
 
 	/**
-	 * Sets up source target panel
-	 * contains input field for source and target
-	 * contains allow Sources Targets In Paths Option check box
+	 * Sets up network panel
+	 * contains drop-down to select network
+	 * contains treat Network As Undirected check box
 	 * contains targets Same As Sources Option check box
 	 */
-	private void setUpSourceTargetPanel() {
-		if (_sourceTargetPanel != null) // stops if panel already created
+	private void setUpNetworkPanel() {
+		if (_networkPanel != null) // stops if panel already created
 			return;
 
 		// initialize the JPanel, panel border, and group layout
-		_sourceTargetPanel = new JPanel();
-		TitledBorder sourceTargetBorder = BorderFactory.createTitledBorder("Sources/Targets");
-		_sourceTargetPanel.setBorder(sourceTargetBorder);
+		_networkPanel = new JPanel();
+		TitledBorder networkBorder = BorderFactory.createTitledBorder("Network");
+		_networkPanel.setBorder(networkBorder);
 
-		final GroupLayout sourceTargetPanelLayout = new GroupLayout(_sourceTargetPanel);
-		_sourceTargetPanel.setLayout(sourceTargetPanelLayout);
-		sourceTargetPanelLayout.setAutoCreateContainerGaps(true);
-		sourceTargetPanelLayout.setAutoCreateGaps(true);
+		final GroupLayout networkPanelLayout = new GroupLayout(_networkPanel);
+		_networkPanel.setLayout(networkPanelLayout);
+		networkPanelLayout.setAutoCreateContainerGaps(true);
+		networkPanelLayout.setAutoCreateGaps(true);
 		
 		_networkCmbLabel = new JLabel("Select network: ");
         _networkCmbLabel.setToolTipText("The network to run PathLinker on");
@@ -823,6 +826,47 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
             }
         });
 
+		_treatNetworkAsUndirectedOption = new JCheckBox("<html>Treat network as undirected</html>", false);
+		_treatNetworkAsUndirectedOption.setToolTipText("Ignore directionality of edges when computing paths");
+		// _treatNetworkAsUndirectedOption.addItemListener(new CheckBoxListener());
+
+		// add all components into the horizontal and vertical group of the GroupLayout
+		networkPanelLayout.setHorizontalGroup(networkPanelLayout.createParallelGroup()
+                .addGroup(networkPanelLayout.createSequentialGroup()
+                        .addComponent(_networkCmbLabel)
+                        .addComponent(_networkCmb))
+				.addGroup(networkPanelLayout.createParallelGroup(Alignment.LEADING, true)
+						.addComponent(_treatNetworkAsUndirectedOption))
+				);
+		networkPanelLayout.setVerticalGroup(networkPanelLayout.createSequentialGroup()
+                .addGroup(networkPanelLayout.createParallelGroup(Alignment.LEADING, true)
+                        .addComponent(_networkCmbLabel)
+                        .addComponent(_networkCmb))
+				.addGroup(networkPanelLayout.createSequentialGroup()
+						.addComponent(_treatNetworkAsUndirectedOption))
+				);
+	}
+
+	/**
+	 * Sets up source target panel
+	 * contains input field for source and target
+	 * contains allow Sources Targets In Paths Option check box
+	 * contains targets Same As Sources Option check box
+	 */
+	private void setUpSourceTargetPanel() {
+		if (_sourceTargetPanel != null) // stops if panel already created
+			return;
+
+		// initialize the JPanel, panel border, and group layout
+		_sourceTargetPanel = new JPanel();
+		TitledBorder sourceTargetBorder = BorderFactory.createTitledBorder("Sources/Targets");
+		_sourceTargetPanel.setBorder(sourceTargetBorder);
+
+		final GroupLayout sourceTargetPanelLayout = new GroupLayout(_sourceTargetPanel);
+		_sourceTargetPanel.setLayout(sourceTargetPanelLayout);
+		sourceTargetPanelLayout.setAutoCreateContainerGaps(true);
+		sourceTargetPanelLayout.setAutoCreateGaps(true);
+		
 		_sourcesLabel = new JLabel("<html>Sources separated by spaces (e.g., S1 S2 S3)" 
                 + "<br>Must match the 'name' column in the Node Table</html>");
 
@@ -866,9 +910,6 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		// add all components into the horizontal and vertical group of the GroupLayout
 		sourceTargetPanelLayout.setHorizontalGroup(sourceTargetPanelLayout.createParallelGroup()
                 .addGroup(sourceTargetPanelLayout.createSequentialGroup()
-                        .addComponent(_networkCmbLabel)
-                        .addComponent(_networkCmb))
-				.addGroup(sourceTargetPanelLayout.createParallelGroup(Alignment.LEADING, true)
 						.addComponent(_sourcesLabel)
 						.addComponent(_sourcesTextField)
 						.addComponent(_loadNodeToSourceButton))
@@ -877,6 +918,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 						.addComponent(_targetsTextField)
 						.addComponent(_loadNodeToTargetButton))
 				.addGroup(sourceTargetPanelLayout.createParallelGroup(Alignment.LEADING, true)
+						.addComponent(_treatNetworkAsUndirectedOption)
 						.addComponent(_allowSourcesTargetsInPathsOption)
 						.addGroup(sourceTargetPanelLayout.createSequentialGroup()
 								.addComponent(_targetsSameAsSourcesOption)
@@ -885,9 +927,6 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 				);
 		sourceTargetPanelLayout.setVerticalGroup(sourceTargetPanelLayout.createSequentialGroup()
                 .addGroup(sourceTargetPanelLayout.createParallelGroup(Alignment.LEADING, true)
-                        .addComponent(_networkCmbLabel)
-                        .addComponent(_networkCmb))
-				.addGroup(sourceTargetPanelLayout.createSequentialGroup()
 						.addComponent(_sourcesLabel)
 						.addComponent(_sourcesTextField)
 						.addComponent(_loadNodeToSourceButton))
@@ -898,6 +937,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 						.addComponent(_loadNodeToTargetButton))
 				.addPreferredGap(ComponentPlacement.RELATED)
 				.addGroup(sourceTargetPanelLayout.createSequentialGroup()
+						.addComponent(_treatNetworkAsUndirectedOption)
 						.addComponent(_allowSourcesTargetsInPathsOption)
 						.addGroup(sourceTargetPanelLayout.createParallelGroup(Alignment.LEADING, true)
 								.addComponent(_targetsSameAsSourcesOption)
@@ -1072,6 +1112,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 
 		// sets up all the sub panels and its components
 		setUpTitlePanel();
+        setUpNetworkPanel();
 		setUpSourceTargetPanel();
 		setUpAlgorithmPanel();
 		setUpGraphPanel();

--- a/src/main/java/com/dpgil/pathlinker/path_linker/internal/view/PathLinkerControlPanel.java
+++ b/src/main/java/com/dpgil/pathlinker/path_linker/internal/view/PathLinkerControlPanel.java
@@ -909,7 +909,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 
 		// add all components into the horizontal and vertical group of the GroupLayout
 		sourceTargetPanelLayout.setHorizontalGroup(sourceTargetPanelLayout.createParallelGroup()
-                .addGroup(sourceTargetPanelLayout.createSequentialGroup()
+				.addGroup(sourceTargetPanelLayout.createParallelGroup(Alignment.LEADING, true)
 						.addComponent(_sourcesLabel)
 						.addComponent(_sourcesTextField)
 						.addComponent(_loadNodeToSourceButton))
@@ -918,7 +918,6 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 						.addComponent(_targetsTextField)
 						.addComponent(_loadNodeToTargetButton))
 				.addGroup(sourceTargetPanelLayout.createParallelGroup(Alignment.LEADING, true)
-						.addComponent(_treatNetworkAsUndirectedOption)
 						.addComponent(_allowSourcesTargetsInPathsOption)
 						.addGroup(sourceTargetPanelLayout.createSequentialGroup()
 								.addComponent(_targetsSameAsSourcesOption)
@@ -926,7 +925,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 						)
 				);
 		sourceTargetPanelLayout.setVerticalGroup(sourceTargetPanelLayout.createSequentialGroup()
-                .addGroup(sourceTargetPanelLayout.createParallelGroup(Alignment.LEADING, true)
+				.addGroup(sourceTargetPanelLayout.createSequentialGroup()
 						.addComponent(_sourcesLabel)
 						.addComponent(_sourcesTextField)
 						.addComponent(_loadNodeToSourceButton))
@@ -937,7 +936,6 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 						.addComponent(_loadNodeToTargetButton))
 				.addPreferredGap(ComponentPlacement.RELATED)
 				.addGroup(sourceTargetPanelLayout.createSequentialGroup()
-						.addComponent(_treatNetworkAsUndirectedOption)
 						.addComponent(_allowSourcesTargetsInPathsOption)
 						.addGroup(sourceTargetPanelLayout.createParallelGroup(Alignment.LEADING, true)
 								.addComponent(_targetsSameAsSourcesOption)
@@ -1140,6 +1138,7 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 		// add all components into the horizontal and vertical group of the GroupLayout
 		mainLayout.setHorizontalGroup(mainLayout.createParallelGroup(Alignment.LEADING, true)
 				.addComponent(_titlePanel)
+				.addComponent(_networkPanel)
 				.addComponent(_sourceTargetPanel)
 				.addComponent(_algorithmPanel)
 				.addComponent(_graphPanel)
@@ -1152,6 +1151,8 @@ public class PathLinkerControlPanel extends JPanel implements CytoPanelComponent
 				);
 		mainLayout.setVerticalGroup(mainLayout.createSequentialGroup()
 				.addComponent(_titlePanel)
+				.addPreferredGap(ComponentPlacement.RELATED)
+				.addComponent(_networkPanel)
 				.addPreferredGap(ComponentPlacement.RELATED)
 				.addComponent(_sourceTargetPanel)
 				.addPreferredGap(ComponentPlacement.RELATED)

--- a/src/test/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModelTest.java
+++ b/src/test/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModelTest.java
@@ -422,7 +422,6 @@ public class PathLinkerModelTest {
 		// set up custom source and target to ensure that graph contains source and targets in paths
 		// create the model for algorithm with k = 26 to ensure relatively small output
 		modelParams = new PathLinkerModelParams();
-		modelParams.treatNetworkAsUndirected = true;
 		modelParams.allowSourcesTargetsInPaths = true;
 		modelParams.includeTiedPaths = includePathScoreTies;
 		modelParams.sources = "P35968 P16333";
@@ -486,7 +485,6 @@ public class PathLinkerModelTest {
 		//k value is set to enumerate all paths of length to 0.5329432500000001 ensure the results will be same,
 		//otherwise results could be correct but different due to the random nature of which paths PathLinker finds first
 		modelParams = new PathLinkerModelParams();
-		modelParams.treatNetworkAsUndirected = true;
 		modelParams.allowSourcesTargetsInPaths = true;
 		modelParams.includeTiedPaths = includePathScoreTies;
 		modelParams.sources = source;

--- a/src/test/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModelTest.java
+++ b/src/test/java/com/dpgil/pathlinker/path_linker/internal/PathLinkerModelTest.java
@@ -422,6 +422,7 @@ public class PathLinkerModelTest {
 		// set up custom source and target to ensure that graph contains source and targets in paths
 		// create the model for algorithm with k = 26 to ensure relatively small output
 		modelParams = new PathLinkerModelParams();
+		modelParams.treatNetworkAsUndirected = true;
 		modelParams.allowSourcesTargetsInPaths = true;
 		modelParams.includeTiedPaths = includePathScoreTies;
 		modelParams.sources = "P35968 P16333";
@@ -434,6 +435,7 @@ public class PathLinkerModelTest {
 		modelParams.validate(originalNetworkDir, "test");
 		testModel = new PathLinkerModel(
 		        originalNetworkDir, 
+                modelParams.treatNetworkAsUndirected,
 		        modelParams.allowSourcesTargetsInPaths, 
 		        modelParams.includeTiedPaths, 
 		        modelParams.getSourceNames(), 
@@ -484,6 +486,7 @@ public class PathLinkerModelTest {
 		//k value is set to enumerate all paths of length to 0.5329432500000001 ensure the results will be same,
 		//otherwise results could be correct but different due to the random nature of which paths PathLinker finds first
 		modelParams = new PathLinkerModelParams();
+		modelParams.treatNetworkAsUndirected = true;
 		modelParams.allowSourcesTargetsInPaths = true;
 		modelParams.includeTiedPaths = includePathScoreTies;
 		modelParams.sources = source;
@@ -496,6 +499,7 @@ public class PathLinkerModelTest {
 		modelParams.validate(originalNetworkDir, "test");
 		testModel = new PathLinkerModel(
 		        originalNetworkDir, 
+                modelParams.treatNetworkAsUndirected,
 		        modelParams.allowSourcesTargetsInPaths, 
 		        modelParams.includeTiedPaths, 
 		        modelParams.getSourceNames(), 
@@ -634,8 +638,11 @@ public class PathLinkerModelTest {
 	/**
 	 * Sets up the test model before testing
 	 */
-	private void modelSetUp(CyNetwork network, int k, EdgeWeightType edgeWeightType, boolean allowSourceTargetInPaths) {
+	private void modelSetUp(CyNetwork network, int k, EdgeWeightType edgeWeightType, 
+            boolean allowSourceTargetInPaths) {
 	    modelParams = new PathLinkerModelParams();
+        // for now, just leave all of the edges as their current edge type
+		modelParams.treatNetworkAsUndirected = false;
 	    modelParams.allowSourcesTargetsInPaths = allowSourceTargetInPaths;
 	    modelParams.includeTiedPaths = includePathScoreTies;
 	    modelParams.sources = source;
@@ -649,6 +656,7 @@ public class PathLinkerModelTest {
 
 	    testModel = new PathLinkerModel(
 	            network, 
+                modelParams.treatNetworkAsUndirected,
 	            modelParams.allowSourcesTargetsInPaths, 
 	            modelParams.includeTiedPaths, 
 	            modelParams.getSourceNames(), 


### PR DESCRIPTION
Added an option to treat the selected network as undirected which is implemented by creating a copy of the network, and adding each edge in the network reversed.

Also created a network panel to hold the "Select network" drop-down and the "Treat edges as undirected" check-box.
![image](https://user-images.githubusercontent.com/7592559/38628835-5675c116-3d80-11e8-9f39-94a4269baed4.png)

